### PR TITLE
Fix bug where Items.load is called before ApiItems has been set.

### DIFF
--- a/StarControl/UI/ConfigurationMenu.cs
+++ b/StarControl/UI/ConfigurationMenu.cs
@@ -18,16 +18,11 @@ internal static class ConfigurationMenu
         // don't get stuck in the UI and become unable to be removed.
         var activeClientMods = pageRegistry.Mods.Select(mod => mod.UniqueID).ToHashSet();
         config.Integrations.Priorities.RemoveAll(p => !activeClientMods.Contains(p.ModId));
-
-        var context = new ConfigurationViewModel(helper, config)
-        {
-            Items =
-            {
-                ApiItems = pageRegistry
-                    .StandaloneItems.Select(x => ApiItemViewModel.FromItem(x.Mod, x.Item))
-                    .ToList(),
-            },
-        };
+        var items = new ItemsConfigurationViewModel();
+        items.ApiItems = pageRegistry
+            .StandaloneItems.Select(x => ApiItemViewModel.FromItem(x.Mod, x.Item))
+            .ToList();
+        var context = new ConfigurationViewModel(helper, config, items);
         context.Controller = asRoot
             ? ViewEngine.OpenRootMenu("Configuration", context)
             : ViewEngine.OpenChildMenu("Configuration", context);

--- a/StarControl/UI/ConfigurationViewModel.cs
+++ b/StarControl/UI/ConfigurationViewModel.cs
@@ -14,7 +14,7 @@ internal partial class ConfigurationViewModel : IDisposable
     public bool Dismissed { get; set; }
     public InputConfigurationViewModel Input { get; } = new();
     public bool IsNavigationDisabled => !IsNavigationEnabled;
-    public ItemsConfigurationViewModel Items { get; } = new();
+    public ItemsConfigurationViewModel Items { get; }
     public ModIntegrationsViewModel Mods { get; }
     public PagerViewModel<NavPageViewModel> Pager { get; } = new();
     public RadialMenuPreview Preview { get; }
@@ -37,10 +37,15 @@ internal partial class ConfigurationViewModel : IDisposable
     private int loadingFrameCount;
     private int loadingPageIndex = 1;
 
-    public ConfigurationViewModel(IModHelper helper, ModConfig config)
+    public ConfigurationViewModel(
+        IModHelper helper,
+        ModConfig config,
+        ItemsConfigurationViewModel items
+    )
     {
         this.helper = helper;
         this.config = config;
+        Items = items;
         var modId = helper.ModContent.ModID;
         var selfPriority = ModPriorityViewModel.Self(modId, Items);
         Mods = new(helper.ModRegistry, selfPriority);


### PR DESCRIPTION
## Repro steps:

- Add a new Item to mod menu: 
![Screen Shot 2025-02-17 at 10 33 25 AM](https://github.com/user-attachments/assets/70951e73-2f24-4a1a-a40b-3a9d0085ae15)


- Close the menu and re-open:
![Screen Shot 2025-02-17 at 10 33 35 AM](https://github.com/user-attachments/assets/8a2879c2-6ec0-46dd-bc23-90e416fe4388)

## Cause:
- Constructor runs first ConfigurationViewModel()
    ```ts
        var context = new ConfigurationViewModel(helper, config)
        {
            Items =
            {
                ApiItems = pageRegistry
                    .StandaloneItems.Select(x => ApiItemViewModel.FromItem(x.Mod, x.Item))
                    .ToList(),
            },
        };
    ```

- Constructor calls Load.config, which calls Items.Load. 
- Items.load create an async task that reads from ApiItems.
- Initializer block runs that sets ApiItems Items to pageregistry.xyz.
- Depending on the timing ApiItems might be empty when it reaches 
    ```ts
        allItemsTask.ContinueWith(t =>
        {
            var allItems = t.Result;
            foreach (var pageConfig in config.ModMenuPages)
            {
                var pageViewModel = new ModMenuPageConfigurationViewModel(Pager.Pages.Count);
                foreach (var itemConfig in pageConfig)
                {
                    var itemViewModel = new ModMenuItemConfigurationViewModel(
                        !string.IsNullOrWhiteSpace(itemConfig.Id)
                            ? itemConfig.Id
                            : IdGenerator.NewId(6),
                        allItems
                    )
                    {
                        ApiItems = ApiItems.Select(item => item.Clone()).ToList(),
                    };
                    itemViewModel.Load(itemConfig);
                    pageViewModel.Items.Add(itemViewModel);
                }
                Pager.Pages.Add(pageViewModel);
            }
    ```

